### PR TITLE
Copilot/fix unicode encoding error

### DIFF
--- a/build.py
+++ b/build.py
@@ -10,6 +10,18 @@ import subprocess
 import shutil
 from pathlib import Path
 
+# Configure UTF-8 encoding for Windows
+if sys.platform == "win32":
+    import io
+    # Reconfigure stdout and stderr to use UTF-8 encoding
+    if hasattr(sys.stdout, 'reconfigure'):
+        sys.stdout.reconfigure(encoding='utf-8')
+        sys.stderr.reconfigure(encoding='utf-8')
+    else:
+        # Fallback for older Python versions
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+
 # Color codes for terminal output
 class Colors:
     BLUE = '\033[94m'


### PR DESCRIPTION
This pull request adds support for UTF-8 terminal output on Windows systems by configuring the encoding for `stdout` and `stderr`. This ensures that output from the build script displays correctly, especially when handling non-ASCII characters.

Platform compatibility improvements:

* [`build.py`](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eR13-R24): Added logic to detect Windows (`win32`) and reconfigure `sys.stdout` and `sys.stderr` to use UTF-8 encoding, including a fallback for older Python versions.